### PR TITLE
Add CRUD functions for company reps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# vim
+*.swp

--- a/app/config.ts
+++ b/app/config.ts
@@ -2,6 +2,8 @@
 import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
 import { getAuth } from "firebase/auth";
+import { getFirestore } from 'firebase/firestore';
+
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -19,6 +21,7 @@ const firebaseConfig = {
 
 // Initialize Firebase
 const app = initializeApp(firebaseConfig);
+const db = getFirestore(app)
 
 // check if analytics is supported
 let analytics = null;
@@ -28,4 +31,4 @@ if (typeof window !== "undefined") {
 
 const auth = getAuth(app);
 
-export { app, analytics, auth };
+export { app, analytics, auth, db };

--- a/app/firebaseUtils.ts
+++ b/app/firebaseUtils.ts
@@ -1,0 +1,21 @@
+import { doc } from "firebase/firestore";
+import { useDocumentData, useCollectionData } from "react-firebase-hooks/firestore";
+import { query, where } from 'firebase/firestore';
+import { db } from "./config";
+
+export function useDoc(pathOrRef) {
+  let ref;
+  if (typeof pathOrRef === "string") {
+    ref = doc(db, pathOrRef);
+  } else {
+    ref = pathOrRef;
+  }
+  const [data, loading] = useDocumentData(ref);
+  return [data || {}, loading || !data];
+}
+
+export function getFromCollection(pathOrRef, collectionQuery) {
+  let ref = (typeof pathOrRef === "string") ? query(collection(db, pathOrRef), where(...collectionQuery)) : pathOrRef;
+  const [data, loading] = useCollectionData(ref)
+  return [data || {}, loading || !data]
+}

--- a/app/firebaseUtils.ts
+++ b/app/firebaseUtils.ts
@@ -1,5 +1,5 @@
 import { doc } from "firebase/firestore";
-import { useDocumentData, useCollectionData } from "react-firebase-hooks/firestore";
+import { useDocumentData, useCollectionData, useCollectionOnce } from "react-firebase-hooks/firestore";
 import { query, where } from 'firebase/firestore';
 import { db } from "./config";
 
@@ -16,6 +16,6 @@ export function useDoc(pathOrRef) {
 
 export function getFromCollection(pathOrRef, collectionQuery) {
   let ref = (typeof pathOrRef === "string") ? query(collection(db, pathOrRef), where(...collectionQuery)) : pathOrRef;
-  const [data, loading] = useCollectionData(ref)
+  const [data, loading] = useCollectionOnce(ref)
   return [data || {}, loading || !data]
 }

--- a/app/seat-list/page.tsx
+++ b/app/seat-list/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// TODO: check for auth, migrate to firebase functions
+import { app, db } from "@/app/config"
+
+import { collection } from 'firebase/firestore';
+import { useAuthState } from "react-firebase-hooks/auth";
+import { useCollection } from 'react-firebase-hooks/firestore';
+import { useForm } from 'react-hook-form';
+
+export default function SeatList() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+
+  // const [snapshot, loading, error] = useCollection(query, options);
+  const [snapshot, loading, error] = useCollection(
+    collection(db, 'companies')
+  );
+
+  const createUser = async (data: Object) => {
+    console.log(data)
+  }
+
+  if (loading) return <h1>Loading...</h1>
+
+  if (error) return <h1>Error: {error.message}</h1>;
+
+  return (
+    <main>
+      <form onSubmit={handleSubmit((data) => createUser(data))}>
+        <input {...register("firstName", { required: true })} />
+        <input {...register("lastName", { required: true })} />
+        <input {...register("email", { required: true })} />
+        <input type="submit" />
+      </form>
+    </main>
+  );
+
+}

--- a/app/seat-list/page.tsx
+++ b/app/seat-list/page.tsx
@@ -7,8 +7,16 @@ import { collection } from 'firebase/firestore';
 import { useAuthState } from "react-firebase-hooks/auth";
 import { useCollection } from 'react-firebase-hooks/firestore';
 import { useForm } from 'react-hook-form';
+import { useState } from 'react';
 
 export default function SeatList() {
+  let [ userCompany ] = useState({
+    name: 'Loading...',
+    location: 'Loading...',
+    description: 'Loading...',
+    imagePublicId: 'Loading...'
+  })
+
   const {
     register,
     handleSubmit,
@@ -20,22 +28,35 @@ export default function SeatList() {
     collection(db, 'companies')
   );
 
-  const createUser = async (data: Object) => {
-    console.log(data)
-  }
+  const addRep = async (data: Object) => { } // TODO; export to firebase function
 
   if (loading) return <h1>Loading...</h1>
 
   if (error) return <h1>Error: {error.message}</h1>;
 
+  if (snapshot) {
+    let data = snapshot.docs[0].data() // TODO: load the user's actual company
+    userCompany = {
+      name: data.name,
+      location: data.location,
+      description: data.description,
+      imagePublicId: data.imagePublicId
+    }
+  }
+
   return (
+
     <main>
-      <form onSubmit={handleSubmit((data) => createUser(data))}>
+      <h1>{ userCompany.name }</h1>
+      <h1>{ userCompany.location }</h1>
+
+      <form onSubmit={handleSubmit((data) => addRep(data))}>
         <input {...register("firstName", { required: true })} />
         <input {...register("lastName", { required: true })} />
         <input {...register("email", { required: true })} />
         <input type="submit" />
       </form>
+
     </main>
   );
 

--- a/app/seat-list/page.tsx
+++ b/app/seat-list/page.tsx
@@ -30,10 +30,6 @@ export default function SeatList() {
     formState: { errors },
   } = useForm();
 
-  const getOppositeStatus = (currStatus) => {
-    return currStatus == 'rep' ? 'admin' : 'rep'
-  }
-
   const addRep = async (data: Object) => {
     const date = new Date();
     date.setDate(date.getDate() + 7);
@@ -54,10 +50,10 @@ export default function SeatList() {
     alert(`Rep ${repName} deleted successfully`)
   }
 
-  const updateRep = async (repId, currStatus, repName) => {
+  const updateRep = async (repId, isRep, repName) => {
     const repRef = doc(db, 'reps', repId)
     await updateDoc(repRef, {
-      'status': getOppositeStatus(currStatus)
+      'isRep': !isRep
     })
 
     alert(`User ${repName} status updated successfully`)
@@ -81,8 +77,8 @@ export default function SeatList() {
             repsData.docs.map((item, id) => {
               return (
                 <li key={id}>
-                  {item.data().name} ({item.data().status})  |
-                  <button onClick={() => updateRep(item.id, item.data().status, item.data().name)}>change status to {getOppositeStatus(item.data().status)}</button> |
+                  {item.data().name} ({item.data().isRep ? 'rep' : 'admin'}) |
+                  <button onClick={() => updateRep(item.id, item.data().isRep, item.data().name)}>change isRep status to {item.data().isRep ? 'admin' : 'rep'}</button> |
                   <button onClick={() => deleteRep(item.id, item.data().name)}>delete</button>
                 </li>
               )

--- a/app/seat-list/page.tsx
+++ b/app/seat-list/page.tsx
@@ -5,7 +5,7 @@ import { app, db, auth } from "@/app/config"
 
 import { useAuthState } from "react-firebase-hooks/auth";
 
-import { collection, doc, addDoc, getDocs, Timestamp } from 'firebase/firestore';
+import { collection, doc, addDoc, deleteDoc, Timestamp } from 'firebase/firestore';
 import { useCollection, useDocumentData } from 'react-firebase-hooks/firestore';
 
 import { useDoc, getFromCollection } from '@/app/firebaseUtils'
@@ -22,6 +22,8 @@ export default function SeatList() {
   const repsRef = company && collection(db, `reps`)
   const [ repsData, loadingReps ] = getFromCollection(repsRef, ['company', '==', company])
 
+  // console.log(repsData.docs[0].id)
+
   const loading = loadingUser || (user && loadingCompany) || loadingReps
 
   const {
@@ -34,7 +36,7 @@ export default function SeatList() {
     const date = new Date();
     date.setDate(date.getDate() + 7);
 
-    const newInviteRef = await addDoc(collection(db, 'companies', company, 'invites'), {
+    await addDoc(collection(db, 'companies', company, 'invites'), {
       firstName: data.firstName, // TODO: refactor into type
       lastName: data.lastName,
       email: data.email,
@@ -43,7 +45,12 @@ export default function SeatList() {
 
     alert(`New invite to ${data.email} sent successfully`)
   }
-  
+
+  const deleteRep = async (repId, repName) => {
+    await deleteDoc(doc(db, 'reps', repId))
+
+    alert(`Rep ${repName} deleted successfully`)
+  }
 
   if (loading) return <h1>Loading...</h1>
 
@@ -58,11 +65,11 @@ export default function SeatList() {
       <h2>Representatives:</h2>
       <ol>
         {
-          repsData && repsData.length > 0 && (
-            repsData.map((item, id) => {
+          repsData && repsData.docs.length > 0 && (
+            repsData.docs.map((item, id) => {
               return (
                 <li key={id}>
-                  <p>{item.name}</p> 
+                  {item.data().name}  | <span onClick={() => deleteRep(item.id, item.data().name)}>delete</span>
                 </li>
               )
             })

--- a/app/seat-list/page.tsx
+++ b/app/seat-list/page.tsx
@@ -5,7 +5,7 @@ import { app, db, auth } from "@/app/config"
 
 import { useAuthState } from "react-firebase-hooks/auth";
 
-import { collection, doc, addDoc, deleteDoc, Timestamp } from 'firebase/firestore';
+import { collection, doc, addDoc, deleteDoc, updateDoc, Timestamp } from 'firebase/firestore';
 import { useCollection, useDocumentData } from 'react-firebase-hooks/firestore';
 
 import { useDoc, getFromCollection } from '@/app/firebaseUtils'
@@ -22,8 +22,6 @@ export default function SeatList() {
   const repsRef = company && collection(db, `reps`)
   const [ repsData, loadingReps ] = getFromCollection(repsRef, ['company', '==', company])
 
-  // console.log(repsData.docs[0].id)
-
   const loading = loadingUser || (user && loadingCompany) || loadingReps
 
   const {
@@ -31,6 +29,10 @@ export default function SeatList() {
     handleSubmit,
     formState: { errors },
   } = useForm();
+
+  const getOppositeStatus = (currStatus) => {
+    return currStatus == 'rep' ? 'admin' : 'rep'
+  }
 
   const addRep = async (data: Object) => {
     const date = new Date();
@@ -52,6 +54,16 @@ export default function SeatList() {
     alert(`Rep ${repName} deleted successfully`)
   }
 
+  const updateRep = async (repId, currStatus, repName) => {
+    const repRef = doc(db, 'reps', repId)
+    await updateDoc(repRef, {
+      'status': getOppositeStatus(currStatus)
+    })
+
+    alert(`User ${repName} status updated successfully`)
+  }
+
+
   if (loading) return <h1>Loading...</h1>
 
   if (error) return <h1>Error: {error.message}</h1>;
@@ -69,7 +81,9 @@ export default function SeatList() {
             repsData.docs.map((item, id) => {
               return (
                 <li key={id}>
-                  {item.data().name}  | <span onClick={() => deleteRep(item.id, item.data().name)}>delete</span>
+                  {item.data().name} ({item.data().status})  |
+                  <button onClick={() => updateRep(item.id, item.data().status, item.data().name)}>change status to {getOppositeStatus(item.data().status)}</button> |
+                  <button onClick={() => deleteRep(item.id, item.data().name)}>delete</button>
                 </li>
               )
             })

--- a/app/seat-list/page.tsx
+++ b/app/seat-list/page.tsx
@@ -1,21 +1,28 @@
 "use client";
 
 // TODO: check for auth, migrate to firebase functions
-import { app, db } from "@/app/config"
+import { app, db, auth } from "@/app/config"
 
-import { collection } from 'firebase/firestore';
 import { useAuthState } from "react-firebase-hooks/auth";
-import { useCollection } from 'react-firebase-hooks/firestore';
+
+import { collection, doc, addDoc, getDocs, Timestamp } from 'firebase/firestore';
+import { useCollection, useDocumentData } from 'react-firebase-hooks/firestore';
+
+import { useDoc, getFromCollection } from '@/app/firebaseUtils'
+
 import { useForm } from 'react-hook-form';
 import { useState } from 'react';
 
 export default function SeatList() {
-  let [ userCompany ] = useState({
-    name: 'Loading...',
-    location: 'Loading...',
-    description: 'Loading...',
-    imagePublicId: 'Loading...'
-  })
+  const [user, loadingUser, error] = useAuthState(auth);
+
+  const [{ company }] = useDoc(user && `reps/${user.uid}`)
+  const companyRef = company && doc(db, `companies/${company}`)
+  const [ companyData, loadingCompany ] = useDoc(companyRef)
+  const repsRef = company && collection(db, `reps`)
+  const [ repsData, loadingReps ] = getFromCollection(repsRef, ['company', '==', company])
+
+  const loading = loadingUser || (user && loadingCompany) || loadingReps
 
   const {
     register,
@@ -23,33 +30,47 @@ export default function SeatList() {
     formState: { errors },
   } = useForm();
 
-  // const [snapshot, loading, error] = useCollection(query, options);
-  const [snapshot, loading, error] = useCollection(
-    collection(db, 'companies')
-  );
+  const addRep = async (data: Object) => {
+    const date = new Date();
+    date.setDate(date.getDate() + 7);
 
-  const addRep = async (data: Object) => { } // TODO; export to firebase function
+    const newInviteRef = await addDoc(collection(db, 'companies', company, 'invites'), {
+      firstName: data.firstName, // TODO: refactor into type
+      lastName: data.lastName,
+      email: data.email,
+      expiresOn: Timestamp.fromDate(date)
+    })
+
+    alert(`New invite to ${data.email} sent successfully`)
+  }
+  
 
   if (loading) return <h1>Loading...</h1>
 
   if (error) return <h1>Error: {error.message}</h1>;
 
-  if (snapshot) {
-    let data = snapshot.docs[0].data() // TODO: load the user's actual company
-    userCompany = {
-      name: data.name,
-      location: data.location,
-      description: data.description,
-      imagePublicId: data.imagePublicId
-    }
-  }
-
   return (
 
     <main>
-      <h1>{ userCompany.name }</h1>
-      <h1>{ userCompany.location }</h1>
+      <h1>{ companyData.name }</h1>
+      <h1>{ companyData.location }</h1>
 
+      <h2>Representatives:</h2>
+      <ol>
+        {
+          repsData && repsData.length > 0 && (
+            repsData.map((item, id) => {
+              return (
+                <li key={id}>
+                  <p>{item.name}</p> 
+                </li>
+              )
+            })
+          )
+        }
+      </ol>
+
+      <h2>Invite a new user</h2>
       <form onSubmit={handleSubmit((data) => addRep(data))}>
         <input {...register("firstName", { required: true })} />
         <input {...register("lastName", { required: true })} />


### PR DESCRIPTION
Added simple CRUD for reps, including a basic UI on `/seat-list`
NOTE: reps in database have 3 fields
```
company: string
name: string
status: "rep" | "admin"
```

Closes #5 